### PR TITLE
Fix: Fixed banner UI inconsistencies

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,13 +1,13 @@
 import { Container, Grid } from '@mui/material'
 import React from 'react'
 import Image from '../../assets/images/share-card.png'
-import '../../scss/about.scss'
+import '../../scss/banner.scss'
 
 const Banner = () => (
 	<Container>
 	<Grid container justifyContent="center">
 		<Grid item xs={12} sm={12} md={12} justifyContent="center">
-			<img src={Image} alt='banner' className="img-fluid" style={{ borderRadius : "10px"}}/>
+			<img src={Image} alt='banner' className="banner img-fluid" style={{ borderRadius : "10px"}}/>
         </Grid>
 	</Grid>
 	</Container>

--- a/src/scss/about.scss
+++ b/src/scss/about.scss
@@ -1,20 +1,17 @@
-@use "./variables" as variables;
+@use './variables' as variables;
 
-.about{
-    background-color: #F8EBEF;
-    padding-bottom: 50px;
-    h1{
-        color: variables.$secondary-color;
-        font-weight: 900;
-        padding: 20px 0;
-    }
-    p{
-        font-size: 22px;
-    }
-    .maxWidth500{
-        max-width: 500px;
-    }
-}
-.img-fluid{
-    max-width: 100%;
+.about {
+	background-color: #f8ebef;
+	padding-bottom: 50px;
+	h1 {
+		color: variables.$secondary-color;
+		font-weight: 900;
+		padding: 20px 0;
+	}
+	p {
+		font-size: 22px;
+	}
+	.maxWidth500 {
+		max-width: 500px;
+	}
 }

--- a/src/scss/banner.scss
+++ b/src/scss/banner.scss
@@ -1,0 +1,7 @@
+.img-fluid{
+    max-width: 100%;
+}
+
+.banner{
+    margin: 80px 0 30px 0;
+}


### PR DESCRIPTION
Changes made in the PR:
@Safnaj @Shehanka 

- Added top and bottom margins to the banner
- Separated banner styles to a new banner.scss

Screenshots
-
Before:
<img width="1440" alt="Screenshot 2021-10-19 at 12 34 21 PM" src="https://user-images.githubusercontent.com/44240093/137862686-6931bf0d-9229-4480-967a-bfdc491c8a52.png">

After:
<img width="914" alt="Screenshot 2021-10-19 at 12 51 42 PM" src="https://user-images.githubusercontent.com/44240093/137862759-54d1cf40-aee4-40b5-b67d-0966b6dd3f43.png">

